### PR TITLE
Fix broken links to fge.github.io in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ run by yourself.
 
 * current stable version: **2.2.6**
   ([ChangeLog](https://github.com/fge/json-schema-validator/wiki/ChangeLog_22x),
-  [Javadoc](http://fge.github.io/json-schema-validator/2.2.x/index.html), [code
+  [Javadoc](http://daveclayton.github.io/json-schema-validator/2.2.x/index.html), [code
   samples](http://fge.github.io/json-schema-validator/2.2.x/index.html?com/github/fge/jsonschema/examples/package-summary.html)).
 * old stable version: **2.0.4**
   ([ChangeLog](https://github.com/fge/json-schema-validator/wiki/ChangeLog_20x),
-  [Javadoc](http://fge.github.io/json-schema-validator/2.0.x/index.html), [code
+  [Javadoc](http://daveclayton.github.io/json-schema-validator/2.0.x/index.html), [code
   samples](http://fge.github.io/json-schema-validator/2.0.x/index.html?com/github/fge/jsonschema/examples/package-summary.html)).
 
 ## Available downloads


### PR DESCRIPTION
Most URLs automatically redirect from `fge` to `daveclayton`, but these links to the Javadoc do not.